### PR TITLE
Reduce header height while keeping logo centered

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,7 +51,7 @@ header {
 }
 
 header .container {
-  padding: 0.5rem 0;
+  padding: 0;
 }
 
 .nav-bar {
@@ -59,6 +59,7 @@ header .container {
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
+  min-height: 80px;
 }
 
 .logo {
@@ -412,7 +413,7 @@ footer {
 /* Responsive */
 @media (max-width: 767px) {
   header .container {
-    padding: 0.75rem 0;
+    padding: 0.5rem 0;
   }
   .logo {
     width: 120px;
@@ -421,6 +422,8 @@ footer {
     flex-direction: column;
     align-items: center;
     gap: 0.75rem;
+    min-height: auto;
+    padding: 0.75rem 0;
   }
   .nav-links {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- lower the header height by removing extra padding and enforcing an 80px minimum nav height
- keep the logo vertically centered and responsive by tuning mobile navigation spacing

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e78eac1dcc832e801d9624b22b4a0f