### PR TITLE
Reduce header height

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,7 +59,8 @@ header .container {
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  min-height: 80px;
+  min-height: 70px;
+  padding: 0.5rem 0;
 }
 
 .logo {


### PR DESCRIPTION
## Summary
- lower the header navigation bar height to 70px while keeping contents vertically centered
- add internal padding so the compact header remains comfortable across breakpoints

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e790874170832ead8a2f741b056b51