### PR TITLE
Adjust header logo margin for balanced spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -68,6 +68,7 @@ header .container {
   max-width: 100%;
   height: auto;
   display: block;
+  margin-left: clamp(1rem, 5vw, 2.5rem);
 }
 
 .nav-links {
@@ -418,6 +419,7 @@ footer {
   }
   .logo {
     width: 120px;
+    margin-left: 0;
   }
   .nav-bar {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add a responsive left margin to the header logo so it stays offset from the screen edge
- reset the logo margin on mobile layouts to keep the stacked navigation centered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0d08bc25c832e91bdea7aa80abfaa